### PR TITLE
Pruning of Blockscout

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -55,28 +55,28 @@ defmodule EthereumJSONRPC.Geth do
   Fetches the pending transactions from the Geth node.
   """
   @impl EthereumJSONRPC.Variant
-  def fetch_pending_transactions(json_rpc_named_arguments) do
-    with {:ok, transaction_data} <-
-           %{id: 1, method: "txpool_content", params: []} |> request() |> json_rpc(json_rpc_named_arguments) do
-      transactions_params =
-        transaction_data["pending"]
-        |> Enum.flat_map(fn {_address, nonce_transactions_map} ->
-          nonce_transactions_map
-          |> Enum.map(fn {_nonce, transaction} ->
-            transaction
-          end)
-        end)
-        |> Transactions.to_elixir()
-        |> Transactions.elixir_to_params()
-        |> Enum.map(fn params ->
-          # txpool_content always returns transaction with 0x0000000000000000000000000000000000000000000000000000000000000000 value in block hash and index is null.
-          # https://github.com/ethereum/go-ethereum/issues/19897
-          %{params | block_hash: nil, index: nil}
-        end)
-
-      {:ok, transactions_params}
-    end
-  end
+  def fetch_pending_transactions(json_rpc_named_arguments), do: :ignore # ezcw: ignore for now
+#    with {:ok, transaction_data} <-
+#           %{id: 1, method: "txpool_content", params: []} |> request() |> json_rpc(json_rpc_named_arguments) do
+#      transactions_params =
+#        transaction_data["pending"]
+#        |> Enum.flat_map(fn {_address, nonce_transactions_map} ->
+#          nonce_transactions_map
+#          |> Enum.map(fn {_nonce, transaction} ->
+#            transaction
+#          end)
+#        end)
+#        |> Transactions.to_elixir()
+#        |> Transactions.elixir_to_params()
+#        |> Enum.map(fn params ->
+#          # txpool_content always returns transaction with 0x0000000000000000000000000000000000000000000000000000000000000000 value in block hash and index is null.
+#          # https://github.com/ethereum/go-ethereum/issues/19897
+#          %{params | block_hash: nil, index: nil}
+#        end)
+#
+#      {:ok, transactions_params}
+#    end
+#  end
 
   defp debug_trace_transaction_requests(id_to_params) when is_map(id_to_params) do
     Enum.map(id_to_params, fn {id, %{hash_data: hash_data}} ->


### PR DESCRIPTION
### The changes:
1. Fetcihing of pending transaction has been blocked in the `apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex`for now and until we find a better solution.

### The ideas:
1. To stop showing the default chain name and links (see scrinshots bellow) on the main page of Blockscout we should run the Blockscout instance with additional environment variables, like:
```bash
export NETWORK="CloudWalk"
export SUBNETWORK="Testnet"
export SUPPORTED_CHAINS='[ { "title": "CloudWalk Testnet", "url": "https://explorer.testnet.cloudwalk.io/", "test_net?": true } ]'
``` 
The additional info about the environment variables can be found in [the Blockscout docs](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
The additional info about the `SUPPORTED_CHAINS` env variable with examples can be found in the description of [PR 1900 of the Blockscout project](https://github.com/blockscout/blockscout/pull/1900).

![Blocksout_links01](https://user-images.githubusercontent.com/97302011/157034979-982155de-813f-4a8c-b63c-11b5a25c0bbd.png)
![Blocksout_links02](https://user-images.githubusercontent.com/97302011/157034988-aaa4b104-2564-4ba9-b72d-a60cf4a502d8.png)

