### PR TITLE
Fix logs API

### DIFF
--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -104,10 +104,11 @@ defmodule Explorer.Etherscan.Logs do
         on: log.transaction_hash == transaction.hash,
         where: transaction.block_number >= ^prepared_filter.from_block,
         where: transaction.block_number <= ^prepared_filter.to_block,
-        where:
-          transaction.to_address_hash == ^address_hash or
-            transaction.from_address_hash == ^address_hash or
-            transaction.created_contract_address_hash == ^address_hash,
+# ezcw: removed to fetch of the events produced by internal transactions even such transactions are not being indexed
+#        where:
+#          transaction.to_address_hash == ^address_hash or
+#            transaction.from_address_hash == ^address_hash or
+#            transaction.created_contract_address_hash == ^address_hash,
         select: map(log, ^@log_fields),
         select_merge: %{
           gas_price: transaction.gas_price,

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -104,11 +104,11 @@ defmodule Explorer.Etherscan.Logs do
         on: log.transaction_hash == transaction.hash,
         where: transaction.block_number >= ^prepared_filter.from_block,
         where: transaction.block_number <= ^prepared_filter.to_block,
-# ezcw: removed to fetch of the events produced by internal transactions even such transactions are not being indexed
-#        where:
-#          transaction.to_address_hash == ^address_hash or
-#            transaction.from_address_hash == ^address_hash or
-#            transaction.created_contract_address_hash == ^address_hash,
+        # ezcw: removed to fetch of the events produced by internal transactions
+        #        where:
+        #          transaction.to_address_hash == ^address_hash or
+        #            transaction.from_address_hash == ^address_hash or
+        #            transaction.created_contract_address_hash == ^address_hash,
         select: map(log, ^@log_fields),
         select_merge: %{
           gas_price: transaction.gas_price,


### PR DESCRIPTION
Lets consider the following RPC REST request example to Blockscout:
```
https://explorer.testnet.cloudwalk.io/api?module=logs&action=getLogs&address=0x7F41498c5f649AFc4E20E6787386724ECf706282&fromBlock=2382724&toBlock=2468865&topic1=0x000000000000000000000000bdcac6e722f23c153fd1b531994aa17191264763&topic2=0x000000000000000000000000bdcac6e722f23c153fd1b531994aa17191264763&topic1_2_opr=or
```
This request has the following parameters:
* module: `logs`
* action: `getLogs`
* address:  `0x7F41498c5f649AFc4E20E6787386724ECf706282`
* fromBlock: `0`
* toBlock: `latest`
* topic1: `0x000000000000000000000000bdcac6e722f23c153fd1b531994aa17191264763`
* topic2: `0x000000000000000000000000bdcac6e722f23c153fd1b531994aa17191264763`
* topic1_2_opr: `or`.

Prior this PR changes the SQL query to Blockscout database caused by the RPC request was equivalent to the following:
```sql
SELECT
	*
FROM
	logs
JOIN
	transactions
ON
	logs.transaction_hash = transactions.hash
WHERE
	logs.address_hash = '\x7F41498c5f649AFc4E20E6787386724ECf706282'::bytea
	AND (
	logs.second_topic = '0x000000000000000000000000bdcac6e722f23c153fd1b531994aa17191264763'
		OR logs.third_topic = '0x000000000000000000000000bdcac6e722f23c153fd1b531994aa17191264763')
	AND (
	logs.address_hash = transactions.to_address_hash
		OR logs.address_hash = transactions.from_address_hash
		OR logs.address_hash = transactions.created_contract_address_hash)
ORDER BY
	logs.block_number
;
```
After the changes, the same query is equivalent to the following:
```sql
SELECT
	*
FROM
	logs
JOIN
	transactions
ON
	logs.transaction_hash = transactions.hash
WHERE
	logs.address_hash = '\x7F41498c5f649AFc4E20E6787386724ECf706282'::bytea
	AND (
	logs.second_topic = '0x000000000000000000000000bdcac6e722f23c153fd1b531994aa17191264763'
		OR logs.third_topic = '0x000000000000000000000000bdcac6e722f23c153fd1b531994aa17191264763')
ORDER BY
	logs.block_number
;
```
No filtering by transaction addresses (fields `to_address_hash`, `from_address_hash`, `created_contract_address_hash`).

Only filtering by the address in logs is remained.