### PR TITLE
chore: REVERT disabling of internal transactions

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -55,28 +55,28 @@ defmodule EthereumJSONRPC.Geth do
   Fetches the pending transactions from the Geth node.
   """
   @impl EthereumJSONRPC.Variant
-  def fetch_pending_transactions(json_rpc_named_arguments), do: :ignore # ezcw: ignore for now
-#    with {:ok, transaction_data} <-
-#           %{id: 1, method: "txpool_content", params: []} |> request() |> json_rpc(json_rpc_named_arguments) do
-#      transactions_params =
-#        transaction_data["pending"]
-#        |> Enum.flat_map(fn {_address, nonce_transactions_map} ->
-#          nonce_transactions_map
-#          |> Enum.map(fn {_nonce, transaction} ->
-#            transaction
-#          end)
-#        end)
-#        |> Transactions.to_elixir()
-#        |> Transactions.elixir_to_params()
-#        |> Enum.map(fn params ->
-#          # txpool_content always returns transaction with 0x0000000000000000000000000000000000000000000000000000000000000000 value in block hash and index is null.
-#          # https://github.com/ethereum/go-ethereum/issues/19897
-#          %{params | block_hash: nil, index: nil}
-#        end)
-#
-#      {:ok, transactions_params}
-#    end
-#  end
+  def fetch_pending_transactions(json_rpc_named_arguments), do:
+   with {:ok, transaction_data} <-
+          %{id: 1, method: "txpool_content", params: []} |> request() |> json_rpc(json_rpc_named_arguments) do
+     transactions_params =
+       transaction_data["pending"]
+       |> Enum.flat_map(fn {_address, nonce_transactions_map} ->
+         nonce_transactions_map
+         |> Enum.map(fn {_nonce, transaction} ->
+           transaction
+         end)
+       end)
+       |> Transactions.to_elixir()
+       |> Transactions.elixir_to_params()
+       |> Enum.map(fn params ->
+         # txpool_content always returns transaction with 0x0000000000000000000000000000000000000000000000000000000000000000 value in block hash and index is null.
+         # https://github.com/ethereum/go-ethereum/issues/19897
+         %{params | block_hash: nil, index: nil}
+       end)
+
+     {:ok, transactions_params}
+   end
+ end
 
   defp debug_trace_transaction_requests(id_to_params) when is_map(id_to_params) do
     Enum.map(id_to_params, fn {id, %{hash_data: hash_data}} ->

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -107,11 +107,10 @@ defmodule Explorer.Etherscan.Logs do
         on: log.transaction_hash == transaction.hash,
         where: transaction.block_number >= ^prepared_filter.from_block,
         where: transaction.block_number <= ^prepared_filter.to_block,
-        # ezcw: removed to fetch of the events produced by internal transactions
-        #        where:
-        #          transaction.to_address_hash == ^address_hash or
-        #            transaction.from_address_hash == ^address_hash or
-        #            transaction.created_contract_address_hash == ^address_hash,
+        where:
+          transaction.to_address_hash == ^address_hash or
+            transaction.from_address_hash == ^address_hash or
+            transaction.created_contract_address_hash == ^address_hash,
         select: map(log, ^@log_fields),
         select_merge: %{
           gas_price: transaction.gas_price,


### PR DESCRIPTION
reverting some code we created to avoid fetching internal transactions before, and re-enabling now that we can support them.

TLDR; REVERTS commits [ddcd4006172b36b0a22bf4b842241c1c67aa35b3](https://github.com/cloudwalk/blockscout/commit/ddcd4006172b36b0a22bf4b842241c1c67aa35b3) AND [1c7343d875d964414377982a443e55290d3c7b43](https://github.com/cloudwalk/blockscout/commit/1c7343d875d964414377982a443e55290d3c7b43)